### PR TITLE
Fixed baseDir undefined error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var gulp = require('gulp'),
 elixir.extend('browserify', function (src, output, options) {
 
     var config = this,
-        baseDir = config.preprocessors.baseDir + 'js',
+        baseDir = config.assetsDir + 'js',
         defaultOptions;
 
     defaultOptions = {


### PR DESCRIPTION
`preprocessors` doesn't seem to exist anymore, so from what I could gather you'd need to use `assetsDir` instead.
