### PR TITLE
Removes gulp-browserify adds new notifications and some cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,13 +17,14 @@
   },
   "license": "MIT",
   "dependencies": {
+    "browserify": "^7.0.3",
     "debowerify": "^0.9.1",
     "gulp-if": "^1.2.5",
     "gulp-notify": "^2.0.0",
-    "gulp-load-plugins": "^0.7.0",
     "gulp-rename": "^1.2.0",
     "gulp-uglify": "^1.0.1",
-    "underscore": "^1.7.0"
+    "underscore": "^1.7.0",
+    "vinyl-transform": "^1.0.0"
   },
   "devDependencies": {},
   "repository": {


### PR DESCRIPTION
Fixes issues in #6 

I've done a couple of things here:
- Using the new Elixir notifications, so there is just less you need to write for that now
- removed gulp-browserify and gulp-load-plugins
- removed baseDir -- made srcDir an option so if a user wanted to use a different resource directory they can
- added the ability to rename your new bundle
- added the ability to rename your new bundle's name

Let me know what you think.  Thanks!
